### PR TITLE
LinAlg: Add softmax operator

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgOps.td
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgOps.td
@@ -468,7 +468,7 @@ def Linalg_IndexOp : Linalg_Op<"index", [NoSideEffect]>,
 
 def Linalg_SoftmaxOp : Linalg_Op<"softmax", [NoSideEffect]> {
   let arguments = (ins AnyTensor:$input,
-                      Confined<I64Attr, [IntMinValue<0>]>:$dim);
+                       I64Attr:$dim);
   let results = (outs AnyTensor:$result);
   let summary = "linalg softmax operation";
   let description = [{

--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgOps.td
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgOps.td
@@ -466,4 +466,16 @@ def Linalg_IndexOp : Linalg_Op<"index", [NoSideEffect]>,
   let hasVerifier = 1;
 }
 
+def Linalg_SoftmaxOp : Linalg_Op<"softmax", [NoSideEffect]> {
+  let arguments = (ins AnyTensor:$input,
+                      Confined<I64Attr, [IntMinValue<0>]>:$dim);
+  let results = (outs AnyTensor:$result);
+  let summary = "linalg softmax operation";
+  let description = [{
+    This implements the softmax operator.
+  }];
+  let assemblyFormat = [{ attr-dict `ins``(` $input `:` type($input)`)` `->` type(results) }];
+  let hasVerifier = 1;
+}
+
 #endif // LINALG_OPS

--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -502,6 +502,10 @@ LogicalResult SoftmaxOp::verify() {
     return failure();
   if (inputTensor.getShape() != outputTensor.getShape())
     return emitOpError("input and output dimensions must be the same");
+
+  auto dimS = dimAttr().getValue().getSExtValue();
+  if (dimS >= inputTensor.getRank() || dimS < -inputTensor.getRank())
+    return emitOpError("dim must be in range [-inputRank, inputRank)");
   return success();
 }
 

--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -492,6 +492,20 @@ void FillOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 //===----------------------------------------------------------------------===//
+// SoftmaxOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult SoftmaxOp::verify() {
+  auto inputTensor = input().getType().dyn_cast<RankedTensorType>();
+  auto outputTensor = result().getType().dyn_cast<RankedTensorType>();
+  if (!inputTensor || !outputTensor)
+    return failure();
+  if (inputTensor.getShape() != outputTensor.getShape())
+    return emitOpError("input and output dimensions must be the same");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // GenericOps
 //===----------------------------------------------------------------------===//
 void GenericOp::build(


### PR DESCRIPTION
Adds a Softmax Operator to linalg, but only via a tablegen definition. So we cannot currently lower it to LinAlg.generic.