### PR TITLE
Liam.fused add order

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgNamedStructuredOps.yaml
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgNamedStructuredOps.yaml
@@ -40,7 +40,7 @@ structured_op: !LinalgStructuredOpConfig
     shape_map: affine_map<()[s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10] -> (s0,
       s10, s2, s6)>
   - !LinalgOperandDefConfig
-    name: stride
+    name: strides
     kind: index_attr
     index_attr_map: affine_map<()[s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10] ->
       (s3, s7)>
@@ -48,7 +48,7 @@ structured_op: !LinalgStructuredOpConfig
     - 1
     - 1
   - !LinalgOperandDefConfig
-    name: dilation
+    name: dilations
     kind: index_attr
     index_attr_map: affine_map<()[s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10] ->
       (s5, s9)>
@@ -161,7 +161,7 @@ structured_op: !LinalgStructuredOpConfig
     shape_map: affine_map<()[s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10] -> (s0,
       s10, s2, s6)>
   - !LinalgOperandDefConfig
-    name: stride
+    name: strides
     kind: index_attr
     index_attr_map: affine_map<()[s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10] ->
       (s3, s7)>
@@ -169,7 +169,7 @@ structured_op: !LinalgStructuredOpConfig
     - 1
     - 1
   - !LinalgOperandDefConfig
-    name: dilation
+    name: dilations
     kind: index_attr
     index_attr_map: affine_map<()[s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10] ->
       (s5, s9)>
@@ -293,7 +293,7 @@ structured_op: !LinalgStructuredOpConfig
     shape_map: affine_map<()[s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12,
       s13, s14, s15, s16, s17, s18, s19, s20] -> (s0, s12, s2, s7)>
   - !LinalgOperandDefConfig
-    name: stride
+    name: strides
     kind: index_attr
     index_attr_map: affine_map<()[s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11,
       s12, s13, s14, s15, s16, s17, s18, s19, s20] -> (s3, s8)>
@@ -301,7 +301,7 @@ structured_op: !LinalgStructuredOpConfig
     - 1
     - 1
   - !LinalgOperandDefConfig
-    name: dilation
+    name: dilations
     kind: index_attr
     index_attr_map: affine_map<()[s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11,
       s12, s13, s14, s15, s16, s17, s18, s19, s20] -> (s6, s11)>
@@ -317,7 +317,7 @@ structured_op: !LinalgStructuredOpConfig
     - 1
     - 1
   - !LinalgOperandDefConfig
-    name: mp_stride
+    name: mp_strides
     kind: index_attr
     index_attr_map: affine_map<()[s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11,
       s12, s13, s14, s15, s16, s17, s18, s19, s20] -> (s4, s9)>
@@ -335,7 +335,7 @@ structured_op: !LinalgStructuredOpConfig
     - 0
     - 0
   - !LinalgOperandDefConfig
-    name: mp_dilation
+    name: mp_dilations
     kind: index_attr
     index_attr_map: affine_map<()[s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11,
       s12, s13, s14, s15, s16, s17, s18, s19, s20] -> (s19, s20)>
@@ -593,6 +593,42 @@ structured_op: !LinalgStructuredOpConfig
           scalar_arg: bias
 --- !LinalgOpConfig
 metadata: !LinalgOpMetadata
+  name: broadcast_bias_2d_fchw
+  cpp_class_name: BroadcastBias2DFchwOp
+  doc: |-
+    Applies the bias value to the input tensor by broadcasting.
+
+    Layout:
+      * Input: NFHW
+      * Bias: F
+structured_op: !LinalgStructuredOpConfig
+  args:
+  - !LinalgOperandDefConfig
+    name: bias
+    kind: input_tensor
+    type_var: T1
+    shape_map: affine_map<()[s0, s1, s2, s3] -> (s0)>
+  - !LinalgOperandDefConfig
+    name: OFM
+    kind: output_tensor
+    type_var: T1
+    shape_map: affine_map<()[s0, s1, s2, s3] -> (s1, s0, s2, s3)>
+  indexing_maps: !LinalgIndexingMapsConfig
+    static_indexing_maps:
+    - affine_map<(d0, d1, d2, d3)[s0, s1, s2, s3] -> (d1)>
+    - affine_map<(d0, d1, d2, d3)[s0, s1, s2, s3] -> (d0, d1, d2, d3)>
+  iterator_types:
+  - parallel
+  - parallel
+  - parallel
+  - parallel
+  assignments:
+  - !ScalarAssign
+    arg: OFM
+    value: !ScalarExpression
+      scalar_arg: bias
+--- !LinalgOpConfig
+metadata: !LinalgOpMetadata
   name: copy
   cpp_class_name: CopyOp
   doc: |-
@@ -728,7 +764,7 @@ structured_op: !LinalgStructuredOpConfig
     shape_map: affine_map<()[s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10] -> (s0,
       s10, s2, s6)>
   - !LinalgOperandDefConfig
-    name: stride
+    name: strides
     kind: index_attr
     index_attr_map: affine_map<()[s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10] ->
       (s3, s7)>
@@ -736,7 +772,7 @@ structured_op: !LinalgStructuredOpConfig
     - 1
     - 1
   - !LinalgOperandDefConfig
-    name: dilation
+    name: dilations
     kind: index_attr
     index_attr_map: affine_map<()[s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10] ->
       (s5, s9)>
@@ -866,7 +902,7 @@ structured_op: !LinalgStructuredOpConfig
     shape_map: affine_map<()[s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10] -> (s0,
       s10, s2, s6)>
   - !LinalgOperandDefConfig
-    name: stride
+    name: strides
     kind: index_attr
     index_attr_map: affine_map<()[s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10] ->
       (s3, s7)>
@@ -874,7 +910,7 @@ structured_op: !LinalgStructuredOpConfig
     - 1
     - 1
   - !LinalgOperandDefConfig
-    name: dilation
+    name: dilations
     kind: index_attr
     index_attr_map: affine_map<()[s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10] ->
       (s5, s9)>
@@ -1008,7 +1044,7 @@ structured_op: !LinalgStructuredOpConfig
     shape_map: affine_map<()[s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10] -> (s0,
       s10, s2, s6)>
   - !LinalgOperandDefConfig
-    name: stride
+    name: strides
     kind: index_attr
     index_attr_map: affine_map<()[s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10] ->
       (s3, s7)>
@@ -1016,7 +1052,7 @@ structured_op: !LinalgStructuredOpConfig
     - 1
     - 1
   - !LinalgOperandDefConfig
-    name: dilation
+    name: dilations
     kind: index_attr
     index_attr_map: affine_map<()[s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10] ->
       (s5, s9)>

--- a/mlir/lib/Dialect/Linalg/Transforms/Unfuse.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Unfuse.cpp
@@ -103,8 +103,8 @@ Value unfuse2DConvolution(
     assert(ifm && weights && bias && "expected 3 operands");
 
     // Infer the result shape of the convolution.
-    auto dilationAttr = op->getAttr("dilation").cast<DenseIntElementsAttr>();
-    auto strideAttr = op->getAttr("stride").cast<DenseIntElementsAttr>();
+    auto dilationAttr = op->getAttr("dilations").cast<DenseIntElementsAttr>();
+    auto strideAttr = op->getAttr("strides").cast<DenseIntElementsAttr>();
     auto resultTy = infer2DConvolutionResultType(
         ifm.getType().cast<RankedTensorType>(),
         weights.getType().cast<RankedTensorType>(),
@@ -432,8 +432,8 @@ struct Conv2DLreluMaxpoolOpLowering : OpRewritePattern<Conv2DLreluMaxpoolOp> {
                 )
             };
             NamedAttribute attributes[] = {
-                rewriter.getNamedAttr("dilations", op->getAttr("mp_dilation")),
-                rewriter.getNamedAttr("strides", op->getAttr("mp_stride"))
+                rewriter.getNamedAttr("dilations", op->getAttr("mp_dilations")),
+                rewriter.getNamedAttr("strides", op->getAttr("mp_strides"))
             };
             rewriter.replaceOpWithNewOp<PoolingNchwMaxOp>(
                 op,

--- a/mlir/lib/Dialect/Linalg/Transforms/Unfuse.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Unfuse.cpp
@@ -95,9 +95,7 @@ Value unfuse2DConvolution(
     Operation* op,
     Value ifm,
     Value weights,
-    Value bias,
-    Value dest = {}
-)
+    Value bias)
 {
     // Sanity check: none of these are optional.
     assert(ifm && weights && bias && "expected 3 operands");
@@ -113,26 +111,13 @@ Value unfuse2DConvolution(
     );
 
     // Ensure we have an appropriately sized destination operand.
-    if (!dest) {
-        auto elementTy = ifm.getType().cast<ShapedType>().getElementType();
-        auto zero = builder.create<arith::ConstantOp>(
-            op->getLoc(),
-            builder.getZeroAttr(elementTy)
-        );
-        dest = builder.create<tensor::SplatOp>(
-            op->getLoc(),
-            zero,
-            resultTy
-        ).getResult();
-    }
-    assert(dest.getType() == resultTy && "expected matching dest");
+    Value dest = builder.create<InitTensorOp>(op->getLoc(), resultTy.getShape(), resultTy.getElementType());
 
     // Apply the bias to dest.
-    //  - We do this before the convolution, since there may be opportunities
-    //    for constant folding / other optimizations.
+    //  - We do this before the convolution, since we assume this is the canonical evaluation order.
     {
-        Value inputs[] = { /*IFM=*/dest, /*bias=*/bias };
-        dest = builder.create<ApplyBias2DFchwOp>(
+        Value inputs[] = { /*bias=*/bias };
+        dest = builder.create<BroadcastBias2DFchwOp>(
             op->getLoc(),
             /*resultTensorTypes=*/resultTy,
             inputs,
@@ -168,17 +153,19 @@ struct Conv2DTensorAddLowering : OpRewritePattern<Conv2DTensorAddOp> {
         assert(op.getNumInputs() == 4 && "expected 4 inputs");
         assert(op.getNumOutputs() == 1 && "expected 1 output");
 
-        // Unfuse the convolution and use the summand directly as destination.
-        rewriter.replaceOp(
+        // Unfuse the convolution.
+        auto convResult = unfuse2DConvolution(
+            rewriter,
             op,
-            unfuse2DConvolution(
-                rewriter,
-                op,
-                /*ifm=*/op.getInputOperand(0)->get(),
-                /*weights=*/op.getInputOperand(2)->get(),
-                /*bias=*/op.getInputOperand(3)->get(),
-                /*dest=*/op.getInputOperand(1)->get()
-            )
+            /*ifm=*/op.getInputOperand(0)->get(),
+            /*weights=*/op.getInputOperand(2)->get(),
+            /*bias=*/op.getInputOperand(3)->get()
+        );
+        // Unfuse the Add.
+        rewriter.replaceOpWithNewOp<arith::AddFOp>(
+            op,
+            convResult,
+            op.getInputOperand(1)->get()
         );
 
         return success();
@@ -202,8 +189,7 @@ struct Conv2DReluLowering : OpRewritePattern<Conv2DReluOp> {
             op,
             /*ifm=*/op.getInputOperand(0)->get(),
             /*weights=*/op.getInputOperand(1)->get(),
-            /*bias=*/op.getInputOperand(2)->get(),
-            /*dest=*/op.getOutputOperand(0)->get()
+            /*bias=*/op.getInputOperand(2)->get()
         );
 
         // Unfuse the ReLU.
@@ -235,16 +221,23 @@ struct Conv2DTensorAddReluLowering : OpRewritePattern<Conv2DTensorAddReluOp> {
             op,
             /*ifm=*/op.getInputOperand(0)->get(),
             /*weights=*/op.getInputOperand(2)->get(),
-            /*bias=*/op.getInputOperand(3)->get(),
-            /*dest=*/op.getInputOperand(1)->get()
+            /*bias=*/op.getInputOperand(3)->get()
         );
+
+        // Unfuse the Add.
+        Value inputs[] = {convResult, op.getInputOperand(1)->get()};
+        auto addResult = rewriter.create<arith::AddFOp>(
+            op->getLoc(),
+            convResult,
+            op.getInputOperand(1)->get()
+        ).getResult();
 
         // Unfuse the ReLU.
         rewriter.replaceOpWithNewOp<Relu2DNchwOp>(
             op,
-            /*resultTensorTypes=*/convResult.getType(),
-            /*inputs=*/convResult,
-            /*outputs=*/convResult
+            /*resultTensorTypes=*/addResult.getType(),
+            /*inputs=*/addResult,
+            /*outputs=*/addResult
         );
 
         return success();
@@ -268,8 +261,7 @@ struct Conv2DLreluOpLowering : OpRewritePattern<Conv2DLreluOp> {
             op,
             /*ifm=*/op.getInputOperand(0)->get(),
             /*weights=*/op.getInputOperand(1)->get(),
-            /*bias=*/op.getInputOperand(2)->get(),
-            /*dest=*/op.getOutputOperand(0)->get()
+            /*bias=*/op.getInputOperand(2)->get()
         );
 
         // Unfuse the leaky ReLU.
@@ -307,21 +299,28 @@ struct Conv2DTensorAddLreluLowering : OpRewritePattern<Conv2DTensorAddLreluOp> {
             op,
             /*ifm=*/op.getInputOperand(0)->get(),
             /*weights=*/op.getInputOperand(2)->get(),
-            /*bias=*/op.getInputOperand(3)->get(),
-            /*dest=*/op.getInputOperand(1)->get()
+            /*bias=*/op.getInputOperand(3)->get()
         );
+
+        // Unfuse the Add.
+        Value inputs[] = {convResult, op.getInputOperand(1)->get()};
+        auto addResult = rewriter.create<arith::AddFOp>(
+            op->getLoc(),
+            convResult,
+            op.getInputOperand(1)->get()
+        ).getResult();
 
         // Unfuse the leaky ReLU.
         {
             Value inputs[] = {
-                /*ifm=*/convResult,
+                /*ifm=*/addResult,
                 /*alpha=*/op.getInputOperand(4)->get()
             };
             rewriter.replaceOpWithNewOp<Lrelu2DNchwOp>(
                 op,
-                /*resultTensorTypes=*/convResult.getType(),
+                /*resultTensorTypes=*/addResult.getType(),
                 inputs,
-                /*outputs=*/convResult
+                /*outputs=*/addResult
             );
         }
 
@@ -385,7 +384,7 @@ struct Conv2DLreluMaxpoolOpLowering : OpRewritePattern<Conv2DLreluMaxpoolOp> {
 
             // Generate a padding value.
             // BUG: xten -> linalg lowering does not pass along the padding
-            //      value! But maxpool is ususally padded with -inf.
+            //      value! But maxpool is usually padded with -inf.
             Attribute padValue;
             if (auto floatTy = elementTy.cast<FloatType>()) {
                 padValue = rewriter.getFloatAttr(

--- a/mlir/python/mlir/dialects/linalg/opdsl/ops/core_named_ops.py
+++ b/mlir/python/mlir/dialects/linalg/opdsl/ops/core_named_ops.py
@@ -130,6 +130,19 @@ def apply_bias_2d_fchw(
   domain(D.b, D.f, D.oh, D.ow)
   OFM[D.b, D.f, D.oh, D.ow] = IFM[D.b, D.f, D.oh, D.ow] + bias[D.f]
 
+@linalg_structured_op
+def broadcast_bias_2d_fchw(
+    bias=TensorDef(T1, S.F),
+    OFM=TensorDef(T1, Batch, S.F, S.OH, S.OW, output=True)):
+  """Applies the bias value to the input tensor by broadcasting.
+  
+  Layout:
+    * Input: NFHW
+    * Bias: F
+  """
+  domain(D.b, D.f, D.oh, D.ow)
+  OFM[D.b, D.f, D.oh, D.ow] = bias[D.f]
+
 # Standard linalg ops
 
 @linalg_structured_op

--- a/mlir/python/mlir/dialects/linalg/opdsl/ops/core_named_ops.py
+++ b/mlir/python/mlir/dialects/linalg/opdsl/ops/core_named_ops.py
@@ -15,8 +15,8 @@ def conv_2d_relu(
     K=TensorDef(T2, S.F, S.C, S.KH, S.KW),
     B=TensorDef(T3, S.F),
     O=TensorDef(U, S.N, S.F, S.OH, S.OW, output=True),
-    stride=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
-    dilation=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   """Performs fused 2-D convolution and relu.
   Layout:
     * Input: NCHW.
@@ -40,8 +40,8 @@ def conv_2d_lrelu(
     B=TensorDef(T3, S.F),
     alpha=ScalarDef(F32),
     O=TensorDef(U, S.N, S.F, S.OH, S.OW, output=True),
-    stride=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
-    dilation=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   """Performs fused 2-D convolution and leaky-relu.
   Layout:
     * Input: NCHW.
@@ -65,12 +65,12 @@ def conv_2d_lrelu_maxpool(
     B=TensorDef(T3, S.F),
     alpha=ScalarDef(F32),
     O=TensorDef(U, S.N, S.F, S.OH, S.OW, output=True),
-    stride=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
-    dilation=IndexAttrDef(S.DH, S.DW, default=[1, 1]),
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1]),
     mp_kernel_size=IndexAttrDef(S.MKH, S.MKW, default=[1, 1]),
-    mp_stride=IndexAttrDef(S.MSH, S.MSW, default=[1, 1]),
+    mp_strides=IndexAttrDef(S.MSH, S.MSW, default=[1, 1]),
     mp_padding=IndexAttrDef(S.MPHL, S.MPHH, S.MPWL, S.MPWH, default=[0, 0, 0, 0]),
-    mp_dilation=IndexAttrDef(S.MDH, S.MDW, default=[1, 1])):
+    mp_dilations=IndexAttrDef(S.MDH, S.MDW, default=[1, 1])):
   """Performs fused 2-D convolution, leaky-relu and max-pool.
   Layout:
     * Input: NCHW.
@@ -165,8 +165,8 @@ def conv_2d_tensor_add(
     K=TensorDef(T2, S.F, S.C, S.KH, S.KW),
     B=TensorDef(T3, S.F),
     O=TensorDef(U, S.N, S.F, S.OH, S.OW, output=True),
-    stride=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
-    dilation=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   """Performs fused 2-D convolution and elementwise add.
 
   Layout:
@@ -192,8 +192,8 @@ def conv_2d_tensor_add_relu(
     K=TensorDef(T2, S.F, S.C, S.KH, S.KW),
     B=TensorDef(T3, S.F),
     O=TensorDef(U, S.N, S.F, S.OH, S.OW, output=True),
-    stride=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
-    dilation=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   """Performs fused 2-D convolution and elementwise add and relu.
 
   Layout:
@@ -220,8 +220,8 @@ def conv_2d_tensor_add_lrelu(
     B=TensorDef(T3, S.F),
     alpha=ScalarDef(F32),
     O=TensorDef(U, S.N, S.F, S.OH, S.OW, output=True),
-    stride=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
-    dilation=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
+    strides=IndexAttrDef(S.SH, S.SW, default=[1, 1]),
+    dilations=IndexAttrDef(S.DH, S.DW, default=[1, 1])):
   """Performs fused 2-D convolution, elementwise add and leaky-relu.
 
   Layout:

--- a/mlir/test/Dialect/Linalg/unfuse.mlir
+++ b/mlir/test/Dialect/Linalg/unfuse.mlir
@@ -12,7 +12,7 @@ func.func @unfuse_conv_2d_tensor_add(%ifm : tensor<1x1024x10x10xf32>, %summand :
 
     %init = tensor.splat %zero : tensor<1x1024x8x8xf32>
     %result = linalg.conv_2d_tensor_add
-        {dilation = dense<1> : tensor<2xi64>, stride = dense<1> : tensor<2xi64>}
+        {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
         ins(%ifm, %summand, %weights, %bias : tensor<1x1024x10x10xf32>, tensor<1x1024x8x8xf32>, tensor<1024x1024x3x3xf32>, tensor<1024xf32>)
         outs(%init : tensor<1x1024x8x8xf32>)
         -> tensor<1x1024x8x8xf32>
@@ -41,7 +41,7 @@ func.func @unfuse_conv_2d_relu(%ifm : tensor<1x1024x17x17xf32>) -> tensor<1x1024
 
     %init = tensor.splat %zero : tensor<1x1024x7x7xf32>
     %result = linalg.conv_2d_relu
-        {dilation = dense<2> : tensor<2xi64>, stride = dense<2> : tensor<2xi64>}
+        {dilations = dense<2> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>}
         ins(%ifm, %weights, %bias : tensor<1x1024x17x17xf32>, tensor<1024x1024x3x3xf32>, tensor<1024xf32>)
         outs(%init : tensor<1x1024x7x7xf32>)
         -> tensor<1x1024x7x7xf32>
@@ -76,7 +76,7 @@ func.func @unfuse_conv_2d_tensor_add_relu(%ifm : tensor<1x1024x17x17xf32>, %summ
 
     %init = tensor.splat %zero : tensor<1x1024x7x7xf32>
     %result = linalg.conv_2d_tensor_add_relu
-        {dilation = dense<2> : tensor<2xi64>, stride = dense<2> : tensor<2xi64>}
+        {dilations = dense<2> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>}
         ins(%ifm, %summand, %weights, %bias : tensor<1x1024x17x17xf32>, tensor<1x1024x7x7xf32>, tensor<1024x1024x3x3xf32>, tensor<1024xf32>)
         outs(%init : tensor<1x1024x7x7xf32>)
         -> tensor<1x1024x7x7xf32>
@@ -111,7 +111,7 @@ func.func @unfuse_conv_2d_lrelu(%ifm : tensor<1x1024x15x15xf32>) -> tensor<1x102
 
     %init = tensor.splat %zero : tensor<1x1024x13x13xf32>
     %result = linalg.conv_2d_lrelu
-        {dilation = dense<1> : tensor<2xi64>, stride = dense<1> : tensor<2xi64>}
+        {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
         ins(%ifm, %weights, %bias, %alpha : tensor<1x1024x15x15xf32>, tensor<1024x1024x3x3xf32>, tensor<1024xf32>, f32)
         outs(%init : tensor<1x1024x13x13xf32>)
         -> tensor<1x1024x13x13xf32>
@@ -148,7 +148,7 @@ func.func @unfuse_conv_2d_tensor_add_lrelu(%ifm : tensor<1x1024x15x15xf32>, %sum
 
     %init = tensor.splat %zero : tensor<1x1024x13x13xf32>
     %result = linalg.conv_2d_tensor_add_lrelu
-        {dilation = dense<1> : tensor<2xi64>, stride = dense<1> : tensor<2xi64>}
+        {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
         ins(%ifm, %summand, %weights, %bias, %alpha : tensor<1x1024x15x15xf32>, tensor<1x1024x13x13xf32>, tensor<1024x1024x3x3xf32>, tensor<1024xf32>, f32)
         outs(%init : tensor<1x1024x13x13xf32>)
         -> tensor<1x1024x13x13xf32>
@@ -186,11 +186,11 @@ func.func @unfuse_conv_2d_lrelu_maxpool(%ifm : tensor<1x1024x15x15xf32>) -> tens
     %init = tensor.splat %zero : tensor<1x1024x7x7xf32>
     %result = linalg.conv_2d_lrelu_maxpool
         {
-            dilation = dense<1> : tensor<2xi64>,
-            stride = dense<1> : tensor<2xi64>,
+            dilations = dense<1> : tensor<2xi64>,
+            strides = dense<1> : tensor<2xi64>,
             mp_kernel_size = dense<2> : tensor<2xi64>,
-            mp_stride = dense<2> : tensor<2xi64>,
-            mp_dilation = dense<1> : tensor<2xi64>,
+            mp_strides = dense<2> : tensor<2xi64>,
+            mp_dilations = dense<1> : tensor<2xi64>,
             mp_padding = dense<[0, 1, 0, 1]> : tensor<4xi64>
         }
         ins(%ifm, %weights, %bias, %alpha : tensor<1x1024x15x15xf32>, tensor<1024x1024x3x3xf32>, tensor<1024xf32>, f32)


### PR DESCRIPTION
The order of fused add ops has the add applied to the result of the conv2d. Use the same order when unfusing to avoid evaluation order differences.

Also `linalg.conv2d` has attributes `dilations` and `strides` instead of `dilation` and `stride`. Our fused variants now also use those names.