### PR TITLE
FXML-638:  LinAlg Linear Operator

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgNamedStructuredOps.yaml
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgNamedStructuredOps.yaml
@@ -783,6 +783,75 @@ structured_op: !LinalgStructuredOpConfig
       scalar_arg: bias
 --- !LinalgOpConfig
 metadata: !LinalgOpMetadata
+  name: broadcast_1d_to_2d
+  cpp_class_name: Broadcast1DTo2DOp
+  doc: |-
+    Broadcast the input tensor from 1D to 2D assuming the
+    input tensor describes a single column.
+
+    Layout:
+      * Input: H
+      * Output: WH
+structured_op: !LinalgStructuredOpConfig
+  args:
+  - !LinalgOperandDefConfig
+    name: input
+    kind: input_tensor
+    type_var: T1
+    shape_map: affine_map<()[s0, s1] -> (s0)>
+  - !LinalgOperandDefConfig
+    name: output
+    kind: output_tensor
+    type_var: T1
+    shape_map: affine_map<()[s0, s1] -> (s1, s0)>
+  indexing_maps: !LinalgIndexingMapsConfig
+    static_indexing_maps:
+    - affine_map<(d0, d1)[s0, s1] -> (d1)>
+    - affine_map<(d0, d1)[s0, s1] -> (d0, d1)>
+  iterator_types:
+  - parallel
+  - parallel
+  assignments:
+  - !ScalarAssign
+    arg: output
+    value: !ScalarExpression
+      scalar_arg: input
+--- !LinalgOpConfig
+metadata: !LinalgOpMetadata
+  name: transpose2d
+  cpp_class_name: Transpose2DOp
+  doc: |-
+    Transposes the 2D input tensor
+
+    Layout:
+      * Input: WH
+      * Output: HW
+structured_op: !LinalgStructuredOpConfig
+  args:
+  - !LinalgOperandDefConfig
+    name: input
+    kind: input_tensor
+    type_var: T1
+    shape_map: affine_map<()[s0, s1] -> (s0, s1)>
+  - !LinalgOperandDefConfig
+    name: output
+    kind: output_tensor
+    type_var: T1
+    shape_map: affine_map<()[s0, s1] -> (s1, s0)>
+  indexing_maps: !LinalgIndexingMapsConfig
+    static_indexing_maps:
+    - affine_map<(d0, d1)[s0, s1] -> (d0, d1)>
+    - affine_map<(d0, d1)[s0, s1] -> (d1, d0)>
+  iterator_types:
+  - parallel
+  - parallel
+  assignments:
+  - !ScalarAssign
+    arg: output
+    value: !ScalarExpression
+      scalar_arg: input
+--- !LinalgOpConfig
+metadata: !LinalgOpMetadata
   name: copy
   cpp_class_name: CopyOp
   doc: |-

--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgOps.td
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgOps.td
@@ -210,6 +210,25 @@ def Linalg_GlobalAveragePool2DOp : Linalg_Op<"globalaveragepool2d", [NoSideEffec
   let hasVerifier = 1;
 }
 
+def Linalg_LinearOp : Linalg_Op<"linear", [NoSideEffect]> {
+  let arguments = (
+    ins AnyTensor:$input, 
+        AnyTensor:$weights, 
+        AnyTensor:$bias
+    );
+  let results = (outs AnyTensor:$result);
+  let summary = "linalg linear operation (y=A*B^T+C)";
+  let description = [{
+    The following custom operator implements the linear operator y=A*B^T+C.
+    Remember, C is broadcastable, therefore it is of rank 1.
+    Linear can be decomposed into two generic linalg operators one broadcasting
+    C into 2D tensor, the other transposing the weights. With a linalg matmul
+    consuming the input tensor, transposed weights and the broadcasted C tensor.
+  }];
+  let assemblyFormat = [{ attr-dict `ins``(` $input `:` type($input)`,` $weights `:` type($weights)`,` $bias `:` type($bias) `)` `->` type(results) }];
+  let hasVerifier = 1;
+}
+
 def Linalg_FusedOp
     : Linalg_Op<"fused", [
         IsolatedFromAbove,

--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -698,6 +698,38 @@ LogicalResult GlobalAveragePool2DOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// Linear
+//===----------------------------------------------------------------------===//
+
+LogicalResult LinearOp::verify() {
+  auto inputTensor = input().getType().dyn_cast<RankedTensorType>();
+  auto weightsTensor = weights().getType().dyn_cast<RankedTensorType>();
+  auto biasTensor = bias().getType().dyn_cast<RankedTensorType>();
+  auto outputTensor = result().getType().dyn_cast<RankedTensorType>();
+
+  if (!inputTensor || !weightsTensor || !biasTensor || !outputTensor)
+    return failure();
+
+  if (inputTensor.getRank() != 2 || weightsTensor.getRank() != 2)
+    return emitOpError("rank of input and weights tensors needs to be 2");
+
+  if (biasTensor.getRank() != 1)
+    return emitOpError("rank of bias tensor needs to be 1");
+
+  // remember linear = A*B^T+C meaning:
+  //   * the dim 1 of input must match dim 1 of the weights
+  //   * the dim 0 of input must match dim 0 of the output
+  //   * the dim 0 of weights must match dim 1 of the output
+  //   * the dim 0 of bias must match dim 1 of the output
+  if ((inputTensor.getShape()[1] != weightsTensor.getShape()[1]) ||
+      (inputTensor.getShape()[0] != outputTensor.getShape()[0]) ||
+      (weightsTensor.getShape()[0] != outputTensor.getShape()[1]) ||
+      (biasTensor.getShape()[0] != outputTensor.getShape()[1]))
+    return emitOpError("input, weights and bias dimensions needs to match");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // FusedOp
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Dialect/Linalg/Transforms/Unfuse.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Unfuse.cpp
@@ -657,13 +657,9 @@ struct LinearLowering : OpRewritePattern<LinearOp> {
     auto biasType = bias.getType().cast<RankedTensorType>();
     auto outputType = output.getType().cast<RankedTensorType>();
 
-    if (inputType.getRank() != 2 || weightsType.getRank() != 2) {
-      return rewriter.notifyMatchFailure(op,
-                                         "input and weights must be rank 2");
-    }
-    if (biasType.getRank() != 1) {
-      return rewriter.notifyMatchFailure(op, "bias must be rank 1");
-    }
+    // Ensure inputs are of correct rank
+    assert(inputType.getRank() == 2 && weightsType.getRank() == 2 &&
+           "input and weights must be rank 2");
 
     // Create a linalg op that transposes the weights tensor
     // The transposedWeights is simply used to describe the output shape.

--- a/mlir/python/mlir/dialects/linalg/opdsl/ops/core_named_ops.py
+++ b/mlir/python/mlir/dialects/linalg/opdsl/ops/core_named_ops.py
@@ -169,6 +169,34 @@ def broadcast_bias_2d_fchw(
   domain(D.b, D.f, D.oh, D.ow)
   OFM[D.b, D.f, D.oh, D.ow] = bias[D.f]
 
+@linalg_structured_op
+def broadcast_1d_to_2d(
+    input=TensorDef(T1, S.H),
+    output=TensorDef(T1,  S.W, S.H, output=True)):
+  """
+  Broadcast the input tensor from 1D to 2D
+  
+  Layout:
+    * Input: H
+    * Output: WH
+  """
+  domain(D.W, D.H)
+  output[D.W, D.H] = input[D.H]
+
+@linalg_structured_op
+def transpose2d(
+    input=TensorDef(T1, S.W, S.H),
+    output=TensorDef(T1,  S.H, S.W, output=True)):
+  """
+  Transposes the 2D input tensor
+  
+  Layout:
+    * Input: WH
+    * Output: HW
+  """
+  domain(D.W, D.H)
+  output[D.H, D.W] = input[D.W, D.H]
+
 # Standard linalg ops
 
 @linalg_structured_op

--- a/mlir/test/Dialect/Linalg/unfuse.mlir
+++ b/mlir/test/Dialect/Linalg/unfuse.mlir
@@ -317,9 +317,6 @@ func.func @unfuse_globalaveragepool2d(%ifm : tensor<1x2048x7x7xf32>) -> tensor<1
 
     return %result : tensor<1x2048x1x1xf32>
 }
-// CHECK: #map0 = affine_map<(d0, d1) -> (d1, d0)> 
-// CHECK: #map1 = affine_map<(d0, d1) -> (d0, d1)> 
-// CHECK: #map2 = affine_map<(d0, d1) -> (d1)> 
 // CHECK: func @unfuse_linear(
 // CHECK-SAME: %[[input:.+]]: tensor<1x2048xf32>, %[[weights:.+]]: tensor<1000x2048xf32>, %[[bias:.+]]: tensor<1000xf32>
 func.func @unfuse_linear(%input: tensor<1x2048xf32>, %weights: tensor<1000x2048xf32>, %bias: tensor<1000xf32>) -> tensor<1x1000xf32> {
@@ -327,15 +324,9 @@ func.func @unfuse_linear(%input: tensor<1x2048xf32>, %weights: tensor<1000x2048x
     %result = linalg.linear ins(%input: tensor<1x2048xf32>, %weights: tensor<1000x2048xf32>, %bias: tensor<1000xf32>) -> tensor<1x1000xf32>
 
 // CHECK:  %[[tweightshape:.+]] = linalg.init_tensor [2048, 1000] : tensor<2048x1000xf32>
-// CHECK:  %[[tweights:.+]] = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]} ins(%[[weights]] : tensor<1000x2048xf32>) outs(%[[tweightshape]] : tensor<2048x1000xf32>) {
-// CHECK:  ^bb0(%[[a:.+]]: f32, %{{.+}}: f32):
-// CHECK:    linalg.yield %[[a]] : f32
-// CHECK:  } -> tensor<2048x1000xf32>
+// CHECK:  %[[tweights:.+]] = linalg.transpose2d ins(%arg1 : tensor<1000x2048xf32>) outs(%0 : tensor<2048x1000xf32>) -> tensor<2048x1000xf32>
 // CHECK:  %[[bias2dshape:.+]] = linalg.init_tensor [1, 1000] : tensor<1x1000xf32>
-// CHECK:  %[[bias2d:.+]] = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel"]} ins(%[[bias]] : tensor<1000xf32>) outs(%[[bias2dshape]] : tensor<1x1000xf32>) {
-// CHECK:  ^bb0(%[[b:.+]]: f32, %{{.+}}: f32):
-// CHECK:    linalg.yield %[[b]] : f32
-// CHECK:  } -> tensor<1x1000xf32>
+// CHECK:  %[[bias2d:.+]] = linalg.broadcast_1d_to_2d ins(%arg2 : tensor<1000xf32>) outs(%2 : tensor<1x1000xf32>) -> tensor<1x1000xf32>
 // CHECK:  %[[out:.+]] = linalg.matmul ins(%[[input]], %[[tweights]] : tensor<1x2048xf32>, tensor<2048x1000xf32>) outs(%[[bias2d]] : tensor<1x1000xf32>) -> tensor<1x1000xf32
 // CHECK: return %[[out]]
 


### PR DESCRIPTION
Extend LinAlg with a new named operator for linear. 
Provide an additional lowering for linear to standard linalg operators. So that the linear operator can be used with testing. 
