### PR TITLE
Add ConvolutionOpInterface to fused ops that begin with a conv2d

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgNamedStructuredOps.yaml
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgNamedStructuredOps.yaml
@@ -786,8 +786,7 @@ metadata: !LinalgOpMetadata
   name: broadcast_1d_to_2d
   cpp_class_name: Broadcast1DTo2DOp
   doc: |-
-    Broadcast the input tensor from 1D to 2D assuming the
-    input tensor describes a single column.
+    Broadcast the input tensor from 1D to 2D
 
     Layout:
       * Input: H
@@ -955,6 +954,8 @@ metadata: !LinalgOpMetadata
     Todo: When this fused op is lowered to generic/affine/loops the inner loop functionality
     is incorrect. Implementation of correct conv_2d_tensor_add functionality. Current
     inner loop functionality is a dummy implementation
+  implements:
+  - LinalgConvolutionOpInterface
 structured_op: !LinalgStructuredOpConfig
   args:
   - !LinalgOperandDefConfig
@@ -1093,6 +1094,8 @@ metadata: !LinalgOpMetadata
     Todo: When this fused op is lowered to generic/affine/loops the inner loop functionality
     is incorrect. Implementation of correct conv_2d_tensor_add_relu functionality. Current
     inner loop functionality is a dummy implementation
+  implements:
+  - LinalgConvolutionOpInterface
 structured_op: !LinalgStructuredOpConfig
   args:
   - !LinalgOperandDefConfig
@@ -1231,6 +1234,8 @@ metadata: !LinalgOpMetadata
     Todo: When this fused op is lowered to generic/affine/loops the inner loop functionality
     is incorrect. Implementation of correct conv_2d_tensor_add_lrelu functionality. Current
     inner loop functionality is a dummy implementation
+  implements:
+  - LinalgConvolutionOpInterface
 structured_op: !LinalgStructuredOpConfig
   args:
   - !LinalgOperandDefConfig

--- a/mlir/python/mlir/dialects/linalg/opdsl/ops/core_named_ops.py
+++ b/mlir/python/mlir/dialects/linalg/opdsl/ops/core_named_ops.py
@@ -244,6 +244,7 @@ def conv_2d_tensor_add(
   is incorrect. Implementation of correct conv_2d_tensor_add functionality. Current
   inner loop functionality is a dummy implementation
   """
+  implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.oh, D.ow, D.c, D.kh, D.kw)
   O[D.n, D.f, D.oh, D.ow] += BinaryFn.add(TypeFn.cast_signed(U, B[D.f]) + TypeFn.cast_signed(
       U, I[D.n, D.c, D.oh * S.SH + D.kh * S.DH,
@@ -271,6 +272,7 @@ def conv_2d_tensor_add_relu(
   is incorrect. Implementation of correct conv_2d_tensor_add_relu functionality. Current
   inner loop functionality is a dummy implementation
   """
+  implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.oh, D.ow, D.c, D.kh, D.kw)
   O[D.n, D.f, D.oh, D.ow] += BinaryFn.add(TypeFn.cast_signed(U, B[D.f]) + TypeFn.cast_signed(
       U, I[D.n, D.c, D.oh * S.SH + D.kh * S.DH,
@@ -299,6 +301,7 @@ def conv_2d_tensor_add_lrelu(
   is incorrect. Implementation of correct conv_2d_tensor_add_lrelu functionality. Current
   inner loop functionality is a dummy implementation
   """
+  implements(ConvolutionOpInterface)
   domain(D.n, D.f, D.oh, D.ow, D.c, D.kh, D.kw)
   O[D.n, D.f, D.oh, D.ow] += alpha * BinaryFn.add(TypeFn.cast_signed(U, B[D.f]) + TypeFn.cast_signed(
       U, I[D.n, D.c, D.oh * S.SH + D.kh * S.DH,


### PR DESCRIPTION
The structured fused ops annotate that they are headed by a conv2d with the ConvolutionOpInterface. This was missed for these ops.