### PR TITLE
FXML-1038 : Draft of a fused op interface for subgraph

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgInterfaces.h
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgInterfaces.h
@@ -47,7 +47,9 @@ enum class OperatorClass {
   Padding = 1 << 6,
   /// Broadcasted operator.
   Broadcast = 1 << 7,
-  LLVM_MARK_AS_BITMASK_ENUM(Broadcast)
+  /// Fused Operator.
+  Fused = 1 << 8,
+  LLVM_MARK_AS_BITMASK_ENUM(Fused)
 };
 
 FailureOr<OperatorClass> parseOperatorClass(StringRef str);

--- a/mlir/lib/Dialect/Linalg/IR/LinalgInterfaces.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgInterfaces.cpp
@@ -857,6 +857,7 @@ FailureOr<OperatorClass> mlir::linalg::parseOperatorClass(StringRef str) {
         .Case("pool", OperatorClass::Pooling)
         .Case("pad", OperatorClass::Padding)
         .Case("bcast", OperatorClass::Broadcast)
+        .Case("fused", OperatorClass::Fused)
         .Default(llvm::None);
   };
 
@@ -903,6 +904,7 @@ raw_ostream& mlir::linalg::operator<<(raw_ostream &os, OperatorClass value) {
     case OperatorClass::Pooling: return "pool";
     case OperatorClass::Padding: return "pad";
     case OperatorClass::Broadcast: return "bcast";
+    case OperatorClass::Fused: return "fused";
     default: llvm_unreachable("unknown OperatorClass item");
     }
   };

--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -939,7 +939,7 @@ void FusedOp::getCanonicalizationPatterns(RewritePatternSet &results,
   results.add<DropUnusedCaptures, DropUnusedResult, EraseEmptyFusedOp>(context);
 }
 
-OperatorClass FusedOp::getOperatorClass() { return OperatorClass::None; }
+OperatorClass FusedOp::getOperatorClass() { return OperatorClass::Fused; }
 
 using MemoryEffect = SideEffects::EffectInstance<MemoryEffects::Effect>;
 
@@ -2312,10 +2312,10 @@ struct OperatorClassInterfaceFallback
     if (isa<tensor::PadOp>(op))
       return OperatorClass::Padding;
     if (isa<Conv2DReluOp, Conv2DLreluOp>(op))
-      return OperatorClass::Convolution | OperatorClass::Activation;
+      return OperatorClass::Convolution | OperatorClass::Activation | OperatorClass::Fused;
     if (isa<Conv2DLreluMaxpoolOp>(op))
       return OperatorClass::Convolution | OperatorClass::Activation |
-             OperatorClass::Padding | OperatorClass::Pooling;
+             OperatorClass::Padding | OperatorClass::Pooling | OperatorClass::Fused;
 
     //
     // Guessing

--- a/mlir/lib/Dialect/Linalg/Transforms/StructuralFusion.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/StructuralFusion.cpp
@@ -601,11 +601,6 @@ private:
     size_t result = 0;
     work.clear();
     getOperation().walk([&](Operation *op, const WalkStage &stage) {
-      if (isa<FusedOp>(op)) {
-        // Do not look into fused ops.
-        return WalkResult::skip();
-      }
-
       if (matches(op, filter)) {
         // Seed this op, but do not look into it.
         if (canWrapInFusedOp(op)) {


### PR DESCRIPTION
Quick add of a `fused` operator interface that can be used as a seed/producer/consumer in order to create multilevel subgraphs. 
Used in experiments regarding the investigation of FXML-1038, not intended to be merged. 
